### PR TITLE
Fix crash when device doesn’t have write permission

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,14 @@ impl UsbIpServer {
         let mut devices = vec![];
         if let Ok(list) = rusb::devices() {
             for dev in list.iter() {
-                let handle = Arc::new(Mutex::new(dev.open().unwrap()));
+                let open_device = match dev.open() {
+                    Ok(dev) => dev,
+                    Err(err) => {
+                        println!("Impossible to share {:?}: {}", dev, err);
+                        continue;
+                    }
+                };
+                let handle = Arc::new(Mutex::new(open_device));
                 let desc = dev.device_descriptor().unwrap();
                 let cfg = dev.active_config_descriptor().unwrap();
                 let mut interfaces = vec![];


### PR DESCRIPTION
Prevents this panic on launch of the host example:
```rust
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Access', src/lib.rs:51:61
```