### PR TITLE
Write padding in unlink response

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,8 @@ async fn handler<T: AsyncReadExt + AsyncWriteExt + Unpin>(
                 socket.write_u32(direction).await?;
                 socket.write_u32(ep).await?;
                 // status
-                socket.write_u32(0).await?;
+                socket.write_i32(0).await?;
+                socket.write_all(&mut padding).await?;
             }
             _ => warn!("Got unknown command {:?}", command),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,7 @@ async fn handler<T: AsyncReadExt + AsyncWriteExt + Unpin>(
                 socket.write_u32(direction).await?;
                 socket.write_u32(ep).await?;
                 // status
-                socket.write_i32(0).await?;
+                socket.write_u32(0).await?;
                 socket.write_all(&mut padding).await?;
             }
             _ => warn!("Got unknown command {:?}", command),


### PR DESCRIPTION
As per [documentation](https://www.kernel.org/doc/html/latest/usb/usbip_protocol.html), an `USBIP_CMD_UNLINK` response should return 24 bytes of padding.

