### PR TITLE
Derive Debug for all structs

### DIFF
--- a/src/cdc.rs
+++ b/src/cdc.rs
@@ -2,7 +2,7 @@
 use super::*;
 
 /// A handler of a CDC ACM(Abstract Control Model)
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct UsbCdcAcmHandler {
     pub tx_buffer: Vec<u8>,
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,9 @@
+use std::fmt::Debug;
+
 use super::*;
 use rusb::Version as rusbVersion;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Version {
     pub major: u8,
     pub minor: u8,
@@ -25,7 +27,7 @@ impl Into<rusbVersion> for Version {
 }
 
 /// Represent a USB device
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UsbDevice {
     pub path: String,
     pub bus_id: String,
@@ -437,7 +439,7 @@ impl UsbDevice {
 }
 
 /// A handler for URB targeting the device
-pub trait UsbDeviceHandler {
+pub trait UsbDeviceHandler: Debug {
     /// Handle a URB(USB Request Block) targeting at this device
     ///
     /// When the lower 4 bits of bmRequestType is zero and the URB is not handled by the library, this function is called

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -5,14 +5,14 @@ use super::*;
 // HID 1.11: https://www.usb.org/sites/default/files/documents/hid1_11.pdf
 // HID Usage Tables 1.12: https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum UsbHidKeyboardHandlerState {
     Idle,
     KeyDown,
 }
 
 /// A handler of a HID keyboard
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct UsbHidKeyboardHandler {
     pub report_descriptor: Vec<u8>,
     pub pending_key_events: VecDeque<UsbHidKeyboardReport>,
@@ -22,7 +22,7 @@ pub struct UsbHidKeyboardHandler {
 /// A report of a HID keyboard
 ///
 /// For definition of key codes, see [HID Usage Tables](https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf)
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct UsbHidKeyboardReport {
     /// Key modifier
     pub modifier: u8,

--- a/src/host.rs
+++ b/src/host.rs
@@ -2,7 +2,7 @@
 use super::*;
 
 /// A handler to pass requests to a USB device of the host
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct UsbHostInterfaceHandler {
     handle: Arc<Mutex<DeviceHandle<GlobalContext>>>,
 }
@@ -92,7 +92,7 @@ impl UsbInterfaceHandler for UsbHostInterfaceHandler {
 }
 
 /// A handler to pass requests to a USB device of the host
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct UsbHostDeviceHandler {
     handle: Arc<Mutex<DeviceHandle<GlobalContext>>>,
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,7 +1,9 @@
+use std::fmt::Debug;
+
 use super::*;
 
 /// Represent a USB interface
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct UsbInterface {
     pub interface_class: u8,
     pub interface_subclass: u8,
@@ -13,7 +15,7 @@ pub struct UsbInterface {
 }
 
 /// A handler of a custom usb interface
-pub trait UsbInterfaceHandler {
+pub trait UsbInterfaceHandler: Debug {
     /// Return the class specific descriptor which is inserted between interface descriptor and endpoint descriptor
     fn get_class_specific_descriptor(&self) -> Vec<u8>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub use setup::*;
 pub use util::*;
 
 /// Main struct of a USB/IP server
+#[derive(Debug, Default)]
 pub struct UsbIpServer {
     devices: Vec<UsbDevice>,
 }


### PR DESCRIPTION
Let all structs derive debug for ease of debugging.

The only thing that I feel is a little questionable about this is making `UsbInterfaceHandler` and `UsbDeviceHandler` into a supertraits of `Debug`. Although not semantically correct, it is meant to force `UsbDevice.device_handler: Option<Arc<Mutex<Box<dyn UsbDeviceHandler + Send>>>>` to be debuggable, so `UsbDevice` can be so as well. Would it be better to maintain a manual implementation here?