### PR TITLE
Add support for modifying devicelist during execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "A library to run USB/IP server"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.22.0", features = ["rt", "net", "io-util"] }
+tokio = { version = "1.22.0", features = ["rt", "net", "io-util", "sync"] }
 log = "0.4.17"
 num-traits = "0.2.15"
 num-derive = "0.3.3"

--- a/examples/cdc_acm_serial.rs
+++ b/examples/cdc_acm_serial.rs
@@ -11,14 +11,16 @@ async fn main() {
     let handler =
         Arc::new(Mutex::new(Box::new(usbip::cdc::UsbCdcAcmHandler::new())
             as Box<dyn usbip::UsbInterfaceHandler + Send>));
-    let server = usbip::UsbIpServer::new_simulated(vec![usbip::UsbDevice::new(0).with_interface(
-        usbip::ClassCode::CDC as u8,
-        usbip::cdc::CDC_ACM_SUBCLASS,
-        0x00,
-        "Test CDC ACM",
-        usbip::cdc::UsbCdcAcmHandler::endpoints(),
-        handler.clone(),
-    )]);
+    let server = Arc::new(usbip::UsbIpServer::new_simulated(vec![
+        usbip::UsbDevice::new(0).with_interface(
+            usbip::ClassCode::CDC as u8,
+            usbip::cdc::CDC_ACM_SUBCLASS,
+            0x00,
+            "Test CDC ACM",
+            usbip::cdc::UsbCdcAcmHandler::endpoints(),
+            handler.clone(),
+        ),
+    ]));
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 3240);
     tokio::spawn(usbip::server(addr, server));
 

--- a/examples/hid_keyboard.rs
+++ b/examples/hid_keyboard.rs
@@ -12,19 +12,21 @@ async fn main() {
         Box::new(usbip::hid::UsbHidKeyboardHandler::new_keyboard())
             as Box<dyn usbip::UsbInterfaceHandler + Send>,
     ));
-    let server = usbip::UsbIpServer::new_simulated(vec![usbip::UsbDevice::new(0).with_interface(
-        usbip::ClassCode::HID as u8,
-        0x00,
-        0x00,
-        "Test HID",
-        vec![usbip::UsbEndpoint {
-            address: 0x81,         // IN
-            attributes: 0x03,      // Interrupt
-            max_packet_size: 0x08, // 8 bytes
-            interval: 10,
-        }],
-        handler.clone(),
-    )]);
+    let server = Arc::new(usbip::UsbIpServer::new_simulated(vec![
+        usbip::UsbDevice::new(0).with_interface(
+            usbip::ClassCode::HID as u8,
+            0x00,
+            0x00,
+            "Test HID",
+            vec![usbip::UsbEndpoint {
+                address: 0x81,         // IN
+                attributes: 0x03,      // Interrupt
+                max_packet_size: 0x08, // 8 bytes
+                interval: 10,
+            }],
+            handler.clone(),
+        ),
+    ]));
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 3240);
     tokio::spawn(usbip::server(addr, server));
 

--- a/examples/host.rs
+++ b/examples/host.rs
@@ -1,12 +1,13 @@
 use env_logger;
 use std::net::*;
+use std::sync::Arc;
 use std::time::Duration;
 use usbip;
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let server = usbip::UsbIpServer::new_from_host();
+    let server = Arc::new(usbip::UsbIpServer::new_from_host());
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 3240);
     tokio::spawn(usbip::server(addr, server));
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,10 +24,14 @@ pub fn verify_descriptor(desc: &[u8]) {
 pub(crate) mod tests {
     use std::{
         io::*,
+        net::SocketAddr,
         pin::Pin,
         task::{Context, Poll},
     };
-    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+    use tokio::{
+        io::{AsyncRead, AsyncWrite, ReadBuf},
+        net::{TcpListener, TcpStream},
+    };
 
     pub(crate) struct MockSocket {
         pub input: Cursor<Vec<u8>>,
@@ -71,6 +75,19 @@ pub(crate) mod tests {
 
         fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
             Poll::Ready(Ok(()))
+        }
+    }
+
+    pub(crate) async fn get_free_address() -> SocketAddr {
+        let stream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        stream.local_addr().unwrap()
+    }
+
+    pub(crate) async fn poll_connect(addr: SocketAddr) -> TcpStream {
+        loop {
+            if let Ok(stream) = TcpStream::connect(addr).await {
+                return stream;
+            }
         }
     }
 }


### PR DESCRIPTION
This is an attempt at creating a solution for #16.

~~Using a [tokio barrier](https://docs.rs/tokio/latest/tokio/sync/struct.Barrier.html) and a control flag, the server should be able to wait for all threads to pause, modify the devicelist, and resume all threads. New functions `UsbIpServer::add_device` and `UsbIpServer::remove_device` has been added, and `handler` has been made into `UsbIpServer::handler`, and made public to allow for other implementations of the server loop.~~

Edit: The implementation has changed a lot, ignore the stuff above.

**Summary:**
- Added `UsbIpServer::add_device(UsbDevice)`
- Added `UsbIpServer::remove_device(UsbDevice)`
- Made `handler` public, in order to be able to create custom server loops themselves. This allows the user of the library to create loops with other listeners that can handle adding or removing devices, through something like `tokio::select!`
- `server` now takes `Arc<UsbIpServer>` instead of `UsbIpServer` directly. This is in order to be able to call  `add_device` and `remove_device` on the struct in other places than the server loop
- Added a bunch of tests

This is a breaking change, mostly due to the change in input for `server`

Closes #16