### PR TITLE
Correct Standard Request Codes

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -62,13 +62,14 @@ pub enum StandardRequest {
     GetStatus = 0,
     ClearFeature = 1,
     SetFeature = 3,
+    SetAddress = 5,
     GetDescriptor = 6,
     SetDescriptor = 7,
     GetConfiguration = 8,
     SetConfiguration = 9,
-    GetInterface = 0xA,
-    SetInterface = 0x11,
-    SynthFrame = 0x12,
+    GetInterface = 10,
+    SetInterface = 11,
+    SynchFrame = 12,
 }
 
 /// A list of defined USB descriptor types


### PR DESCRIPTION
This fixes #20 by correcting the value.
I also added in the `SetAddress` code as I can't think of a good reason why it shouldn't be there and fixed the spelling of `SynchFrame`.