### PR TITLE
Fix busId comparions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,11 +240,10 @@ async fn handler<T: AsyncReadExt + AsyncWriteExt + Unpin>(
                 let _status = socket.read_u32().await?;
                 let mut bus_id = [0u8; 32];
                 socket.read_exact(&mut bus_id).await?;
+                let bus_id_compare = &bus_id[..bus_id.iter().position(|&x| x == 0).unwrap_or(bus_id.len())];
                 current_import_device = None;
                 for device in &server.devices {
-                    let mut expected = device.bus_id.as_bytes().to_vec();
-                    expected.resize(32, 0);
-                    if str_eq(&expected, &bus_id) {
+                    if bus_id_compare == device.bus_id.as_bytes() {
                         current_import_device = Some(device);
                         info!("Found device {:?}", device.path);
                         break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ async fn handler<T: AsyncReadExt + AsyncWriteExt + Unpin>(
                 for device in &server.devices {
                     let mut expected = device.bus_id.as_bytes().to_vec();
                     expected.resize(32, 0);
-                    if expected == bus_id {
+                    if str_eq(&expected, &bus_id) {
                         current_import_device = Some(device);
                         info!("Found device {:?}", device.path);
                         break;

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,13 +20,6 @@ pub fn verify_descriptor(desc: &[u8]) {
     assert_eq!(offset, desc.len());
 }
 
-pub fn str_eq(a: &[u8], b: &[u8]) -> bool {
-    let a_idx = a.iter().position(|&x| x == 0).unwrap_or(a.len());
-    let b_idx = b.iter().position(|&x| x == 0).unwrap_or(b.len());
-
-    a[..a_idx] == b[..b_idx]
-}
-
 #[cfg(test)]
 pub(crate) mod tests {
     use std::{

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,6 +20,18 @@ pub fn verify_descriptor(desc: &[u8]) {
     assert_eq!(offset, desc.len());
 }
 
+pub fn str_eq(a: &[u8], b: &[u8]) -> bool {
+    for (x, y) in a.iter().chain([0].iter()).zip(b.iter().chain([0].iter())) {
+        if x != y {
+            return false;
+        }
+        if *x == 0 {
+            return true;
+        }
+    }
+    unreachable!()
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use std::{

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,15 +21,10 @@ pub fn verify_descriptor(desc: &[u8]) {
 }
 
 pub fn str_eq(a: &[u8], b: &[u8]) -> bool {
-    for (x, y) in a.iter().chain([0].iter()).zip(b.iter().chain([0].iter())) {
-        if x != y {
-            return false;
-        }
-        if *x == 0 {
-            return true;
-        }
-    }
-    unreachable!()
+    let a_idx = a.iter().position(|&x| x == 0).unwrap_or(a.len());
+    let b_idx = b.iter().position(|&x| x == 0).unwrap_or(b.len());
+
+    a[..a_idx] == b[..b_idx]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This partly fixes #3.
Changes the busId check to use a null-terminated string comparison.