### PR TITLE
Add `transfer_buffer_length` to `handle_urb`

### DIFF
--- a/src/cdc.rs
+++ b/src/cdc.rs
@@ -47,6 +47,7 @@ impl UsbInterfaceHandler for UsbCdcAcmHandler {
         &mut self,
         _interface: &UsbInterface,
         ep: UsbEndpoint,
+        _transfer_buffer_length: u32,
         _setup: SetupPacket,
         req: &[u8],
     ) -> Result<Vec<u8>> {

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -89,6 +89,7 @@ impl UsbInterfaceHandler for UsbHidKeyboardHandler {
         &mut self,
         _interface: &UsbInterface,
         ep: UsbEndpoint,
+        _transfer_buffer_length: u32,
         setup: SetupPacket,
         _req: &[u8],
     ) -> Result<Vec<u8>> {

--- a/src/host.rs
+++ b/src/host.rs
@@ -18,6 +18,7 @@ impl UsbInterfaceHandler for UsbHostInterfaceHandler {
         &mut self,
         _interface: &UsbInterface,
         ep: UsbEndpoint,
+        transfer_buffer_length: u32,
         setup: SetupPacket,
         req: &[u8],
     ) -> Result<Vec<u8>> {
@@ -25,7 +26,7 @@ impl UsbInterfaceHandler for UsbHostInterfaceHandler {
             "To host device: ep={:?} setup={:?} req={:?}",
             ep, setup, req
         );
-        let mut buffer = vec![0u8; ep.max_packet_size as usize];
+        let mut buffer = vec![0u8; transfer_buffer_length as usize];
         let timeout = std::time::Duration::new(1, 0);
         let handle = self.handle.lock().unwrap();
         if ep.attributes == EndpointAttributes::Control as u8 {
@@ -104,9 +105,14 @@ impl UsbHostDeviceHandler {
 }
 
 impl UsbDeviceHandler for UsbHostDeviceHandler {
-    fn handle_urb(&mut self, setup: SetupPacket, req: &[u8]) -> Result<Vec<u8>> {
+    fn handle_urb(
+        &mut self,
+        transfer_buffer_length: u32,
+        setup: SetupPacket,
+        req: &[u8],
+    ) -> Result<Vec<u8>> {
         debug!("To host device: setup={:?} req={:?}", setup, req);
-        let mut buffer = [0u8; 1024];
+        let mut buffer = vec![0u8; transfer_buffer_length as usize];
         let timeout = std::time::Duration::new(1, 0);
         let handle = self.handle.lock().unwrap();
         // control

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -19,11 +19,13 @@ pub trait UsbInterfaceHandler {
 
     /// Handle a URB(USB Request Block) targeting at this interface
     ///
-    /// Can be one of: control transfer to ep0 or other types of transfer to its endpoint
+    /// Can be one of: control transfer to ep0 or other types of transfer to its endpoint.
+    /// The resulting data should not exceed `transfer_buffer_length`.
     fn handle_urb(
         &mut self,
         interface: &UsbInterface,
         ep: UsbEndpoint,
+        transfer_buffer_length: u32,
         setup: SetupPacket,
         req: &[u8],
     ) -> Result<Vec<u8>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,13 @@ async fn handler<T: AsyncReadExt + AsyncWriteExt + Unpin>(
                 trace!("->Setup {:02x?}", setup);
                 trace!("->Request {:02x?}", out_data);
                 let resp = device
-                    .handle_urb(usb_ep, intf, SetupPacket::parse(&setup), &out_data)
+                    .handle_urb(
+                        usb_ep,
+                        intf,
+                        transfer_buffer_length,
+                        SetupPacket::parse(&setup),
+                        &out_data,
+                    )
                     .await?;
 
                 if out {
@@ -315,7 +321,7 @@ async fn handler<T: AsyncReadExt + AsyncWriteExt + Unpin>(
                     // In the out endpoint case, the actual_length field should be
                     // same as the data length received in the original URB transaction.
                     // No data bytes are sent
-                    transfer_buffer_length as u32
+                    transfer_buffer_length
                 } else {
                     resp.len() as u32
                 };


### PR DESCRIPTION
Closes #24.

This breaks the API. Since #18 is also breaking, could I ask both to be released under a new major version when they eventually get reviewed and merged?

Also, should we enforce people to conform to the given buffer length by providing a mutable slice and making `handle_urb -> Result<()>`, rather than the comment?