### PR TITLE
Update main workflow with several changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ${{ steps.coverage.outputs.report }}
+      if: github.event_name == 'pull_request'
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --all-features --verbose
 
   check:
     runs-on: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
     - name: Check code format
       run: cargo fmt -- --check
     - name: Check clippy
-      run: cargo clippy -- --deny warnings
+      run: cargo clippy --all-features -- --deny warnings
 
   test:
     runs-on: '${{ matrix.os }}'
@@ -37,7 +37,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
     - name: Run tests
-      run: cargo test
+      run: cargo test --all-features
       env:
         CARGO_INCREMENTAL: '0'
         RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,21 @@
 name: CI
-
 on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
+    - name: Build
+      run: cargo build --verbose
 
+  check:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -19,8 +28,22 @@ jobs:
       run: cargo fmt -- --check
     - name: Check clippy
       run: cargo clippy -- --deny warnings
-    - name: Build
-      run: cargo build --verbose
+
+  test:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+          - os: ubuntu-latest
+          - os: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
     - uses: actions-rs/cargo@v1
       with:
         command: test
@@ -34,7 +57,27 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ${{ steps.coverage.outputs.report }}
+
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
     - name: Run benchmarks
       run: cargo bench --verbose
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
     - name: Build docs
       run: cargo doc --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,18 +46,6 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ${{ steps.coverage.outputs.report }}
 
-  benchmarks:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-    - name: Run benchmarks
-      run: cargo bench --verbose
-
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,25 +5,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Build
       run: cargo build --verbose
 
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@nightly
       with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-        components: rustfmt, clippy
+        components: clippy, rustfmt
     - name: Check code format
       run: cargo fmt -- --check
     - name: Check clippy
@@ -38,15 +31,10 @@ jobs:
           - os: ubuntu-latest
           - os: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@nightly
+    - name: Run tests
+      run: cargo test
       env:
         CARGO_INCREMENTAL: '0'
         RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
@@ -61,7 +49,7 @@ jobs:
   benchmarks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
@@ -73,11 +61,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Build docs
       run: cargo doc --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@nightly
+    - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --verbose
 
@@ -17,6 +18,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
       with:
         components: clippy, rustfmt
+    - uses: Swatinem/rust-cache@v2
     - name: Check code format
       run: cargo fmt -- --check
     - name: Check clippy
@@ -33,6 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@nightly
+    - uses: Swatinem/rust-cache@v2
     - name: Run tests
       run: cargo test
       env:
@@ -52,5 +55,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@nightly
+    - uses: Swatinem/rust-cache@v2
     - name: Build docs
       run: cargo doc --verbose


### PR DESCRIPTION
The pipeline has been updated with the following changes:

- Run all steps in parallell
- Update several of the steps, also [the entirety of actions-rs seems to be unmaintained](https://github.com/actions-rs/toolchain/issues/216)
- Only run coveralls on PRs, to avoid breaking workflows on forks
- Add dependency cache to speed up the builds.
- Remove the benchmarking step, we have no benchmarks

We're still using `action-rs/grcov` which might break at some point as it's using deprecated API functions. I haven't found any good alternatives for this yet. But I think this should at least make less things break whenever the API gets deprecated for good.