### PR TITLE
Handle rusb device descriptor errors without panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,13 +54,32 @@ impl UsbIpServer {
             let open_device = match dev.open() {
                 Ok(dev) => dev,
                 Err(err) => {
-                    warn!("Impossible to share {:?}: {}", dev, err);
+                    warn!("Impossible to share {:?}: {}, ignoring device", dev, err);
                     continue;
                 }
             };
+            let desc = match dev.device_descriptor() {
+                Ok(desc) => desc,
+                Err(err) => {
+                    warn!(
+                        "Impossible to get device descriptor for {:?}: {}, ignoring device",
+                        dev, err
+                    );
+                    continue;
+                }
+            };
+            let cfg = match dev.active_config_descriptor() {
+                Ok(desc) => desc,
+                Err(err) => {
+                    warn!(
+                        "Impossible to get config descriptor for {:?}: {}, ignoring device",
+                        dev, err
+                    );
+                    continue;
+                }
+            };
+
             let handle = Arc::new(Mutex::new(open_device));
-            let desc = dev.device_descriptor().unwrap();
-            let cfg = dev.active_config_descriptor().unwrap();
             let mut interfaces = vec![];
             handle
                 .lock()


### PR DESCRIPTION
This won't fix the root cause of #15 and #30, but it will at least handle any similar errors without the panic.

I think it's safe to assume that a USB device should have device and config descriptors, so there's probably an underlying issue in the macos kernel, libusb or rusb.