### PR TITLE
Fixup serde impls

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,4 +1,5 @@
-use super::*;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Parse the SETUP packet of control transfers
 #[derive(Clone, Copy, Debug, Default)]

--- a/src/usbip_protocol.rs
+++ b/src/usbip_protocol.rs
@@ -9,6 +9,9 @@
 use std::io::Result;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::UsbDevice;
 
 /// USB/IP protocol version
@@ -40,6 +43,7 @@ pub const USBIP_RET_UNLINK: u16 = 0x0004;
 /// All commands/responses which rely on a device being attached
 /// to a client use this header.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UsbIpHeaderBasic {
     pub command: u32,
     pub seqnum: u32,
@@ -97,6 +101,7 @@ impl UsbIpHeaderBasic {
 
 /// Client side commands from the Virtual Host Controller
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum UsbIpCommand {
     OpReqDevlist {
         status: u32,
@@ -272,6 +277,7 @@ impl UsbIpCommand {
 
 /// Server side responses from the USB Host
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum UsbIpResponse {
     OpRepDevlist {
         status: u32,


### PR DESCRIPTION
After the few past merges, there were some new types that should have serde impls in #19 as well. This PR adds these impls, and makes clippy happy by adding a conditional macro on an import