### PR TITLE
add support for android no-rusb-open workaround

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -1,6 +1,4 @@
 //! Host USB
-use rusb::DeviceHandle;
-
 use super::*;
 
 /// A handler to pass requests to a USB device of the host

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,4 +1,6 @@
 //! Host USB
+use rusb::DeviceHandle;
+
 use super::*;
 
 /// A handler to pass requests to a USB device of the host

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 use log::*;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use rusb::*;
+use rusb::{ConfigDescriptor, Device, DeviceDescriptor, DeviceHandle, GlobalContext};
 use std::any::Any;
 use std::collections::{HashMap, VecDeque};
 use std::io::{ErrorKind, Result};
@@ -54,151 +54,155 @@ impl UsbIpServer {
         }
     }
 
-    fn with_devices(device_list: Vec<Device<GlobalContext>>) -> Vec<UsbDevice> {
-        let mut devices = vec![];
-
-        for dev in device_list {
-            let open_device = match dev.open() {
-                Ok(dev) => dev,
-                Err(err) => {
-                    warn!("Impossible to share {:?}: {}, ignoring device", dev, err);
-                    continue;
-                }
-            };
-            let desc = match dev.device_descriptor() {
-                Ok(desc) => desc,
-                Err(err) => {
-                    warn!(
-                        "Impossible to get device descriptor for {:?}: {}, ignoring device",
-                        dev, err
-                    );
-                    continue;
-                }
-            };
-            let cfg = match dev.active_config_descriptor() {
-                Ok(desc) => desc,
-                Err(err) => {
-                    warn!(
-                        "Impossible to get config descriptor for {:?}: {}, ignoring device",
-                        dev, err
-                    );
-                    continue;
-                }
-            };
-
-            let handle = Arc::new(Mutex::new(open_device));
-            let mut interfaces = vec![];
+    fn rusb_device_to_usbip_device(device: Device<GlobalContext>, device_handle: DeviceHandle<GlobalContext>, desc: DeviceDescriptor, cfg: ConfigDescriptor) -> UsbDevice {
+        let handle = Arc::new(Mutex::new(device_handle));
+        let mut interfaces = vec![];
+        handle
+            .lock()
+            .unwrap()
+            .set_auto_detach_kernel_driver(true)
+            .ok();
+        for intf in cfg.interfaces() {
+            // ignore alternate settings
+            let intf_desc = intf.descriptors().next().unwrap();
             handle
                 .lock()
                 .unwrap()
                 .set_auto_detach_kernel_driver(true)
                 .ok();
-            for intf in cfg.interfaces() {
-                // ignore alternate settings
-                let intf_desc = intf.descriptors().next().unwrap();
-                handle
-                    .lock()
-                    .unwrap()
-                    .set_auto_detach_kernel_driver(true)
-                    .ok();
-                let mut endpoints = vec![];
+            let mut endpoints = vec![];
 
-                for ep_desc in intf_desc.endpoint_descriptors() {
-                    endpoints.push(UsbEndpoint {
-                        address: ep_desc.address(),
-                        attributes: ep_desc.transfer_type() as u8,
-                        max_packet_size: ep_desc.max_packet_size(),
-                        interval: ep_desc.interval(),
-                    });
-                }
-
-                let handler = Arc::new(Mutex::new(Box::new(UsbHostInterfaceHandler::new(
-                    handle.clone(),
-                ))
-                    as Box<dyn UsbInterfaceHandler + Send>));
-                interfaces.push(UsbInterface {
-                    interface_class: intf_desc.class_code(),
-                    interface_subclass: intf_desc.sub_class_code(),
-                    interface_protocol: intf_desc.protocol_code(),
-                    endpoints,
-                    string_interface: intf_desc.description_string_index().unwrap_or(0),
-                    class_specific_descriptor: Vec::from(intf_desc.extra()),
-                    handler,
+            for ep_desc in intf_desc.endpoint_descriptors() {
+                endpoints.push(UsbEndpoint {
+                    address: ep_desc.address(),
+                    attributes: ep_desc.transfer_type() as u8,
+                    max_packet_size: ep_desc.max_packet_size(),
+                    interval: ep_desc.interval(),
                 });
             }
-            let mut device = UsbDevice {
-                path: format!(
-                    "/sys/bus/{}/{}/{}",
-                    dev.bus_number(),
-                    dev.address(),
-                    dev.port_number()
-                ),
-                bus_id: format!(
-                    "{}-{}-{}",
-                    dev.bus_number(),
-                    dev.address(),
-                    dev.port_number()
-                ),
-                bus_num: dev.bus_number() as u32,
-                dev_num: dev.port_number() as u32,
-                speed: dev.speed() as u32,
-                vendor_id: desc.vendor_id(),
-                product_id: desc.product_id(),
-                device_class: desc.class_code(),
-                device_subclass: desc.sub_class_code(),
-                device_protocol: desc.protocol_code(),
-                device_bcd: desc.device_version().into(),
-                configuration_value: cfg.number(),
-                num_configurations: desc.num_configurations(),
-                ep0_in: UsbEndpoint {
-                    address: 0x80,
-                    attributes: EndpointAttributes::Control as u8,
-                    max_packet_size: desc.max_packet_size() as u16,
-                    interval: 0,
-                },
-                ep0_out: UsbEndpoint {
-                    address: 0x00,
-                    attributes: EndpointAttributes::Control as u8,
-                    max_packet_size: desc.max_packet_size() as u16,
-                    interval: 0,
-                },
-                interfaces,
-                device_handler: Some(Arc::new(Mutex::new(Box::new(UsbHostDeviceHandler::new(
-                    handle.clone(),
-                ))))),
-                usb_version: desc.usb_version().into(),
-                ..UsbDevice::default()
-            };
 
-            // set strings
-            if let Some(index) = desc.manufacturer_string_index() {
-                device.string_manufacturer = device.new_string(
-                    &handle
-                        .lock()
-                        .unwrap()
-                        .read_string_descriptor_ascii(index)
-                        .unwrap(),
-                )
-            }
-            if let Some(index) = desc.product_string_index() {
-                device.string_product = device.new_string(
-                    &handle
-                        .lock()
-                        .unwrap()
-                        .read_string_descriptor_ascii(index)
-                        .unwrap(),
-                )
-            }
-            if let Some(index) = desc.serial_number_string_index() {
-                device.string_serial = device.new_string(
-                    &handle
-                        .lock()
-                        .unwrap()
-                        .read_string_descriptor_ascii(index)
-                        .unwrap(),
-                )
-            }
-            devices.push(device);
+            let handler = Arc::new(Mutex::new(Box::new(UsbHostInterfaceHandler::new(
+                handle.clone(),
+            ))
+                as Box<dyn UsbInterfaceHandler + Send>));
+            interfaces.push(UsbInterface {
+                interface_class: intf_desc.class_code(),
+                interface_subclass: intf_desc.sub_class_code(),
+                interface_protocol: intf_desc.protocol_code(),
+                endpoints,
+                string_interface: intf_desc.description_string_index().unwrap_or(0),
+                class_specific_descriptor: Vec::from(intf_desc.extra()),
+                handler,
+            });
+        }
+        let mut device = UsbDevice {
+            path: format!(
+                "/sys/bus/{}/{}/{}",
+                device.bus_number(),
+                device.address(),
+                device.port_number()
+            ),
+            bus_id: format!(
+                "{}-{}-{}",
+                device.bus_number(),
+                device.address(),
+                device.port_number()
+            ),
+            bus_num: device.bus_number() as u32,
+            dev_num: device.port_number() as u32,
+            speed: device.speed() as u32,
+            vendor_id: desc.vendor_id(),
+            product_id: desc.product_id(),
+            device_class: desc.class_code(),
+            device_subclass: desc.sub_class_code(),
+            device_protocol: desc.protocol_code(),
+            device_bcd: desc.device_version().into(),
+            configuration_value: cfg.number(),
+            num_configurations: desc.num_configurations(),
+            ep0_in: UsbEndpoint {
+                address: 0x80,
+                attributes: EndpointAttributes::Control as u8,
+                max_packet_size: desc.max_packet_size() as u16,
+                interval: 0,
+            },
+            ep0_out: UsbEndpoint {
+                address: 0x00,
+                attributes: EndpointAttributes::Control as u8,
+                max_packet_size: desc.max_packet_size() as u16,
+                interval: 0,
+            },
+            interfaces,
+            device_handler: Some(Arc::new(Mutex::new(Box::new(UsbHostDeviceHandler::new(
+                handle.clone(),
+            ))))),
+            usb_version: desc.usb_version().into(),
+            ..UsbDevice::default()
+        };
+
+        // set strings
+        if let Some(index) = desc.manufacturer_string_index() {
+            device.string_manufacturer = device.new_string(
+                &handle
+                    .lock()
+                    .unwrap()
+                    .read_string_descriptor_ascii(index)
+                    .unwrap(),
+            )
+        }
+        if let Some(index) = desc.product_string_index() {
+            device.string_product = device.new_string(
+                &handle
+                    .lock()
+                    .unwrap()
+                    .read_string_descriptor_ascii(index)
+                    .unwrap(),
+            )
+        }
+        if let Some(index) = desc.serial_number_string_index() {
+            device.string_serial = device.new_string(
+                &handle
+                    .lock()
+                    .unwrap()
+                    .read_string_descriptor_ascii(index)
+                    .unwrap(),
+            )
+        }
+
+        device
+    }
+
+    fn with_devices(device_list: Vec<Device<GlobalContext>>) -> Vec<UsbDevice> {
+        let mut devices = vec![];
+
+        for device in device_list {
+            let device_handle = match device.open() {
+                Ok(device_handle) => device_handle,
+                Err(err) => {
+                    warn!("Impossible to share {:?}: {}, ignoring device", device, err);
+                    continue;
+                }
+            };
+            let desc = match device.device_descriptor() {
+                Ok(desc) => desc,
+                Err(err) => {
+                    warn!(
+                        "Impossible to get device descriptor for {:?}: {}, ignoring device",
+                        device, err
+                    );
+                    continue;
+                }
+            };
+            let cfg = match device.active_config_descriptor() {
+                Ok(desc) => desc,
+                Err(err) => {
+                    warn!(
+                        "Impossible to get config descriptor for {:?}: {}, ignoring device",
+                        device, err
+                    );
+                    continue;
+                }
+            };
+            devices.push(Self::rusb_device_to_usbip_device(device, device_handle, desc, cfg));
         }
         devices
     }
@@ -241,6 +245,13 @@ impl UsbIpServer {
 
     pub async fn add_device(&self, device: UsbDevice) {
         self.available_devices.write().await.push(device);
+    }
+
+    pub async fn add_device_from_device_handle(&self, device_handle: DeviceHandle<GlobalContext>) {
+        let device = device_handle.device();
+        let device_descriptor = device.device_descriptor().unwrap();
+        let active_configuration_descriptor = device.active_config_descriptor().unwrap();
+        self.available_devices.write().await.push(Self::rusb_device_to_usbip_device(device, device_handle, device_descriptor, active_configuration_descriptor));
     }
 
     pub async fn remove_device(&self, bus_id: &str) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 use log::*;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use rusb::{ConfigDescriptor, Device, DeviceDescriptor, DeviceHandle, GlobalContext};
+use rusb::*;
 use std::any::Any;
 use std::collections::{HashMap, VecDeque};
 use std::io::{ErrorKind, Result};


### PR DESCRIPTION
Let me know your thoughts.

```rust
use std::ffi::c_int;

use rusb::{GlobalContext, DeviceHandle, UsbContext};

pub fn libusb_init_from_fd(fd: i32) -> Option<DeviceHandle<GlobalContext>> {
    log::info!("libusb_init_from_fd fd = {fd}");
    // android workaround
    #[cfg(target_os = "android")]
    let _ = rusb::disable_device_discovery();
    // fd -> device_handle
    let global_context = GlobalContext::default();
    let libusb_context = global_context.as_raw();
    let mut fd_handle = std::ptr::null_mut();
    let ret_val = unsafe { libusb1_sys::libusb_wrap_sys_device(libusb_context, fd as *mut c_int, &mut fd_handle) };
    if ret_val != 0 {
        log::error!("libusb_wrap_sys_device failed ret_val = {ret_val}");
        return None;
    }
    let handle_ptr = std::ptr::NonNull::new(fd_handle).unwrap();
    let device_handle = unsafe { DeviceHandle::from_libusb(global_context, handle_ptr) };
    // return
    Some(device_handle)
}

#[no_mangle]
unsafe extern "C" fn libusb_init_from_fd_wrapper(fd: i32) {
    log::info!("libusb_init_from_fd_wrapper fd = {fd}");
    // do custom android libusb init
    let device_handle = usb::libusb_init_from_fd(fd).unwrap();
    // create tokio runtime
    let runtime = tokio::runtime::Builder::new_multi_thread()
        .enable_all()
        .build()
        .unwrap();
    // spawn usbip server on thread
    let _handle = std::thread::spawn(move || {
        let server = Arc::new(usbip::UsbIpServer::new_from_device_handle(device_handle));
        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 3240);
        let _ = runtime.block_on(usbip::server(addr, server));
    });
}
```

Rust library that provides JNI for Java to call:

```rust
#[no_mangle]
pub extern "C" fn Java_com_redacted_redacted_RemoterWrapperLib_StartUsbIpHost(_env: JNIEnv, _obj: JObject) {
    // load library which has extra libusb_init_from_fd_wrapper export added to it
    let driver_filename = DRIVER_FILENAME.get().unwrap();
    let library = Library::load(&driver_filename).unwrap();
    // call libusb_init_from_fd_wrapper
    let fd = USB_DEVICE_FD.get().unwrap();
    let libusb_init_from_fd_wrapper: LibusbInitFromFdWrapperFn = unsafe { library.sym("libusb_init_from_fd_wrapper\0").unwrap() };
    unsafe {
        libusb_init_from_fd_wrapper(*fd);
    }
}
```