### PR TITLE
Fix two host-passthrough crashes hit by real USB-serial devices

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -52,10 +52,6 @@ pub enum EndpointAttributes {
     Interrupt,
 }
 
-/// USB endpoint direction: IN or OUT
-/// Already exists in rusb crate
-pub use rusb::Direction;
-
 /// Emulated max packet size of EP0
 pub const EP0_MAX_PACKET_SIZE: u16 = 64;
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -476,9 +476,16 @@ impl UsbDevice {
                         let mut handler = intf.handler.lock().unwrap();
                         handler.handle_urb(intf, ep, transfer_buffer_length, setup_packet, out_data)
                     }
-                    _ if setup_packet.request_type & 0xF == 0 && self.device_handler.is_some() => {
-                        // to device
-                        // see https://www.beyondlogic.org/usbnutshell/usb6.shtml
+                    _ if self.device_handler.is_some() => {
+                        // to device, endpoint, or other: device_handler implementations
+                        // (e.g. RusbUsbHostDeviceHandler, NusbUsbHostDeviceHandler in host.rs)
+                        // reconstruct the recipient from setup_packet.request_type themselves
+                        // and pass it through to the real transfer, so they're correct for any
+                        // recipient - restricting this arm to recipient 0 (Device) only meant
+                        // Endpoint/Other-recipient requests fell through to unimplemented!()
+                        // below. Some USB-serial chips (e.g. WCH's CH34x/CH9102 family) use
+                        // vendor-specific, non-Device-recipient control transfers to configure
+                        // line state, which hit exactly this case during real passthrough.
                         let lock = self.device_handler.as_ref().unwrap();
                         let mut handler = lock.lock().unwrap();
                         handler.handle_urb(transfer_buffer_length, setup_packet, out_data)
@@ -512,9 +519,10 @@ impl UsbDevice {
                         let mut handler = intf.handler.lock().unwrap();
                         handler.handle_urb(intf, ep, transfer_buffer_length, setup_packet, out_data)
                     }
-                    _ if setup_packet.request_type & 0xF == 0 && self.device_handler.is_some() => {
-                        // to device
-                        // see https://www.beyondlogic.org/usbnutshell/usb6.shtml
+                    _ if self.device_handler.is_some() => {
+                        // to device, endpoint, or other - see the matching arm in the
+                        // control-in match above for why the recipient restriction was
+                        // dropped.
                         let lock = self.device_handler.as_ref().unwrap();
                         let mut handler = lock.lock().unwrap();
                         handler.handle_urb(transfer_buffer_length, setup_packet, out_data)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,32 +279,29 @@ impl UsbIpServer {
             };
 
             // set strings
+            //
+            // Devices are not required to respond successfully to a string descriptor
+            // read (some transiently NAK it, some don't implement the language ID we
+            // ask for). A failure here used to be treated as fatal via .unwrap(), which
+            // crashed enumeration - and with it every other device - instead of just
+            // leaving that one string unset.
             if let Some(index) = desc.manufacturer_string_index() {
-                device.string_manufacturer = device.new_string(
-                    &handle
-                        .lock()
-                        .unwrap()
-                        .read_string_descriptor_ascii(index)
-                        .unwrap(),
-                )
+                match handle.lock().unwrap().read_string_descriptor_ascii(index) {
+                    Ok(s) => device.string_manufacturer = device.new_string(&s),
+                    Err(err) => warn!("failed to read manufacturer string descriptor: {err}"),
+                }
             }
             if let Some(index) = desc.product_string_index() {
-                device.string_product = device.new_string(
-                    &handle
-                        .lock()
-                        .unwrap()
-                        .read_string_descriptor_ascii(index)
-                        .unwrap(),
-                )
+                match handle.lock().unwrap().read_string_descriptor_ascii(index) {
+                    Ok(s) => device.string_product = device.new_string(&s),
+                    Err(err) => warn!("failed to read product string descriptor: {err}"),
+                }
             }
             if let Some(index) = desc.serial_number_string_index() {
-                device.string_serial = device.new_string(
-                    &handle
-                        .lock()
-                        .unwrap()
-                        .read_string_descriptor_ascii(index)
-                        .unwrap(),
-                )
+                match handle.lock().unwrap().read_string_descriptor_ascii(index) {
+                    Ok(s) => device.string_serial = device.new_string(&s),
+                    Err(err) => warn!("failed to read serial number string descriptor: {err}"),
+                }
             }
             devices.push(device);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,19 +288,28 @@ impl UsbIpServer {
             if let Some(index) = desc.manufacturer_string_index() {
                 match handle.lock().unwrap().read_string_descriptor_ascii(index) {
                     Ok(s) => device.string_manufacturer = device.new_string(&s),
-                    Err(err) => warn!("[{:04x}:{:04x} {}] failed to read manufacturer string descriptor (index={index}): {err}", device.vendor_id, device.product_id, device.bus_id),
+                    Err(err) => warn!(
+                        "[{:04x}:{:04x} {}] failed to read manufacturer string descriptor (index={index}): {err}",
+                        device.vendor_id, device.product_id, device.bus_id
+                    ),
                 }
             }
             if let Some(index) = desc.product_string_index() {
                 match handle.lock().unwrap().read_string_descriptor_ascii(index) {
                     Ok(s) => device.string_product = device.new_string(&s),
-                    Err(err) => warn!("[{:04x}:{:04x} {}] failed to read product string descriptor (index={index}): {err}", device.vendor_id, device.product_id, device.bus_id),
+                    Err(err) => warn!(
+                        "[{:04x}:{:04x} {}] failed to read product string descriptor (index={index}): {err}",
+                        device.vendor_id, device.product_id, device.bus_id
+                    ),
                 }
             }
             if let Some(index) = desc.serial_number_string_index() {
                 match handle.lock().unwrap().read_string_descriptor_ascii(index) {
                     Ok(s) => device.string_serial = device.new_string(&s),
-                    Err(err) => warn!("[{:04x}:{:04x} {}] failed to read serial number string descriptor (index={index}): {err}", device.vendor_id, device.product_id, device.bus_id),
+                    Err(err) => warn!(
+                        "[{:04x}:{:04x} {}] failed to read serial number string descriptor (index={index}): {err}",
+                        device.vendor_id, device.product_id, device.bus_id
+                    ),
                 }
             }
             devices.push(device);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,19 +288,19 @@ impl UsbIpServer {
             if let Some(index) = desc.manufacturer_string_index() {
                 match handle.lock().unwrap().read_string_descriptor_ascii(index) {
                     Ok(s) => device.string_manufacturer = device.new_string(&s),
-                    Err(err) => warn!("failed to read manufacturer string descriptor: {err}"),
+                    Err(err) => warn!("[{:04x}:{:04x} {}] failed to read manufacturer string descriptor (index={index}): {err}", device.vendor_id, device.product_id, device.bus_id),
                 }
             }
             if let Some(index) = desc.product_string_index() {
                 match handle.lock().unwrap().read_string_descriptor_ascii(index) {
                     Ok(s) => device.string_product = device.new_string(&s),
-                    Err(err) => warn!("failed to read product string descriptor: {err}"),
+                    Err(err) => warn!("[{:04x}:{:04x} {}] failed to read product string descriptor (index={index}): {err}", device.vendor_id, device.product_id, device.bus_id),
                 }
             }
             if let Some(index) = desc.serial_number_string_index() {
                 match handle.lock().unwrap().read_string_descriptor_ascii(index) {
                     Ok(s) => device.string_serial = device.new_string(&s),
-                    Err(err) => warn!("failed to read serial number string descriptor: {err}"),
+                    Err(err) => warn!("[{:04x}:{:04x} {}] failed to read serial number string descriptor (index={index}): {err}", device.vendor_id, device.product_id, device.bus_id),
                 }
             }
             devices.push(device);


### PR DESCRIPTION
Ran into both of these while passing a physical USB-serial adapter
(WCH CH9102, USB VID/PID `1a86:55d3`, enumerates as \"USB Single Serial\")
through `new_from_host()` / the `host` example to a Docker container on
macOS. Two separate bugs, both crash the whole host process rather than
just failing the one device.

## 1. `device.rs`: control transfer dispatch recipient restriction

The control-in and control-out dispatch only forwards to `device_handler`
when the request's recipient is `Device` (`request_type & 0xF == 0`):

```rust
_ if setup_packet.request_type & 0xF == 0 && self.device_handler.is_some() => {
    // to device
    ...
}
_ => unimplemented!("control out"),
```

But `device_handler` implementations (`RusbUsbHostDeviceHandler`,
`NusbUsbHostDeviceHandler` in `host.rs`) reconstruct the *full* recipient
(`Device`/`Interface`/`Endpoint`/`Other`) from `setup_packet.request_type`
themselves before submitting the real transfer - they're already correct
for any recipient. The narrower guard here meant `Endpoint`/`Other`-recipient
requests fell through to `unimplemented!("control in"/"control out")`
instead, panicking whichever task was handling that transfer.

Some USB-serial chips use vendor-specific, non-`Device`-recipient control
transfers to configure line state instead of standard CDC-ACM class
requests - the WCH chip above is one - and hit this on every real
connection attempt.

**Verified:** built the `host` example with this fix, ran it against the
same physical device passed through to a Linux container via USB/IP, and
confirmed via `dmesg` inside the container that the device attached
cleanly and bound to `cdc_acm`/`ttyACM0` with no panic in the host
process's log - where before the fix it panicked mid-transfer on every
attempt.

## 2. `lib.rs`: string descriptor read panics the whole enumeration pass

`with_rusb_device_handles()` reads each device's manufacturer/product/
serial-number string descriptors with `.unwrap()`. A string descriptor
read isn't guaranteed to succeed (a device can NAK it, or not support the
requested language ID), and when it fails, the `.unwrap()` panics -
taking down the entire synchronous enumeration pass in `new_from_host()`,
and with it every other already-successfully-enumerated device on the
bus, not just the one that failed.

Changed to log a warning and leave that one string unset on failure,
matching the existing `Err` handling a few lines up in the same function
for `device_info.open()` / `dev.active_configuration()`.

Note `with_nusb_devices()` doesn't have this problem - it reads strings
via `device_info.manufacturer_string()` etc., which return `Option<&str>`
from already-cached enumeration data rather than doing a live descriptor
read that can fail.

**Verified:** `cargo build --release` and `cargo test` both clean (29
existing tests + 2 doctests, all passing) with this change. I didn't
reproduce the exact triggering condition live (would need a device that
reliably NAKs a string descriptor read); the fix is a straightforward
narrowing of an existing `Err` path already handled elsewhere in the same
function, not new logic.

---

Happy to adjust either fix if you'd prefer a different approach (e.g.
surfacing the endpoint/other recipient distinction to `device_handler`
explicitly rather than deferring entirely to its own reconstruction, or
a different fallback for the string descriptor failure).